### PR TITLE
restructured Dockerfile in order to better use cached image layers wh…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,24 @@
 FROM node:6.1.0
 MAINTAINER astronomer <greg@astronomer.io>
 
-# Add standard files on downstream builds.
-ONBUILD ADD lib /usr/local/src/lib
-ONBUILD ADD test /usr/local/src/test
-ONBUILD ADD package.json /usr/local/src/
-ONBUILD ADD .babelrc /usr/local/src/
-ONBUILD ADD .eslintrc /usr/local/src/
-
 # Make directory for bunyan logs
 RUN mkdir -p /usr/local/src/log
 ENV LOG_PATH /usr/local/src/log
 
-# Switch to src dir and install node modules.
 ONBUILD WORKDIR /usr/local/src
+
+# copy package.json and install modules
+ONBUILD COPY package.json .
 ONBUILD RUN ["npm", "install"]
+
+# Add standard files on downstream builds.
+# Add lib and test last to use docker layer caching for previous layers
+# especially npm install. Avoids downstream images needing to run npm install
+# on every change to lib or test files
+ONBUILD COPY .babelrc .
+ONBUILD COPY .eslintrc .
+ONBUILD COPY lib lib
+ONBUILD COPY test test
 
 # Execute task-runner installed with the activity with arguments provided from CMD.
 # We might want to split out the executor and the utils into aries-executor and aries-utils.


### PR DESCRIPTION
…en making changes and running tests within a container on downstream builds. This prevents changes in lib or test triggering npm install on every build