### PR TITLE
singleS3StreamOutput constructs a string object if the output of an a…

### DIFF
--- a/dist/decorators/singleS3StreamOutput.js
+++ b/dist/decorators/singleS3StreamOutput.js
@@ -98,7 +98,10 @@ function singleS3StreamOutput() {
                                 case 5:
 
                                     // Create new string object if output is string literal.
-                                    source = (0, _lodash2.default)(output) ? String(output) : output;
+                                    // highland does not accept a single string literal argument.
+                                    // Must be a String object.
+                                    // eslint-disable-next-line no-new-wrappers
+                                    source = (0, _lodash2.default)(output) ? new String(output) : output;
 
                                     // get meter stream to count bytes in stream
 

--- a/lib/decorators/singleS3StreamOutput.js
+++ b/lib/decorators/singleS3StreamOutput.js
@@ -48,7 +48,10 @@ export default function singleS3StreamOutput(split = false) {
                 if (!output) return;
 
                 // Create new string object if output is string literal.
-                const source = isString(output) ? String(output) : output;
+                // highland does not accept a single string literal argument.
+                // Must be a String object.
+                // eslint-disable-next-line no-new-wrappers
+                const source = isString(output) ? new String(output) : output;
 
                 // get meter stream to count bytes in stream
                 const streamCounter = meter();


### PR DESCRIPTION
…ctivity was a string. This commit reverts 557e514. This is required due to the highland constructor not accepting a lone string literal param